### PR TITLE
Rewrite text handling for the future.

### DIFF
--- a/lib/github.com/diku-dk/lys/common.mk
+++ b/lib/github.com/diku-dk/lys/common.mk
@@ -25,7 +25,7 @@ $(PROGNAME): $(PROGNAME)_wrapper.o $(PROGNAME)_printf.h $(FONT_DEPS) $(FRONTEND_
 	gcc $(FRONTEND_DIR)/liblys.c $(SELF_DIR)/shared.c $(FRONTEND_DIR)/main.c -I. -I$(SELF_DIR) -DPROGHEADER='"$(PROGNAME)_wrapper.h"' -DPRINTFHEADER='"$(PROGNAME)_printf.h"' -DLYS_TEXT $(PROGNAME)_wrapper.o -o $@ $(CFLAGS) $(LDFLAGS)
 endif
 
-$(PROGNAME)_printf.h: $(PROGNAME)_wrapper.c
+$(PROGNAME)_printf.h: $(PROGNAME)_wrapper.json
 	python3 $(SELF_DIR)/gen_printf.py $(FRONTEND_DIR) $@ $<
 
 font_data.h: $(SELF_DIR)/Inconsolata-Regular.ttf

--- a/lib/github.com/diku-dk/lys/gen_printf.py
+++ b/lib/github.com/diku-dk/lys/gen_printf.py
@@ -2,15 +2,49 @@
 
 import sys
 import re
+import json
 
 self_dir, out_file, in_file = sys.argv[1:]
 
 with open(in_file) as f:
-    contents = f.read()
+    manifest = json.load(f)
 
-start = contents.find('futhark_entry_text_content')
-end = contents.find(')', start)
-types = re.findall(r'([^ ]+) \*out\d+,', contents[start:end])
+contents_type = manifest['entry_points']['text_content']['outputs'][0]['type']
+
+C_TYPE_MAPPING = { 'u8': 'uint8_t',
+                   'u16': 'uint16_t',
+                   'u32': 'uint32_t',
+                   'u64': 'uint64_t',
+                   'i8': 'int8_t',
+                   'i16': 'int16_t',
+                   'i32': 'int32_t',
+                   'i64': 'int64_t',
+                   'f16': 'uint16_t',
+                   'f32': 'float',
+                   'f64': 'double',
+                   'bool': 'bool'
+                  }
+
+def to_c_type(t):
+    if t in manifest['types']:
+        return manifest['types'][t]['ctype']
+    else:
+        return C_TYPE_MAPPING[t]
+
+contents_ctype = to_c_type(contents_type)
+
+if contents_type in manifest['types']:
+    fields=manifest['types'][contents_type]['record']['fields']
+    n_printf_arguments = len(fields)
+    types = [ to_c_type(f['type']) for f in fields ]
+    projects = [ f['project'] for f in fields ]
+    free = manifest['types'][contents_type]['ops']['free']
+else:
+    n_printf_arguments = 1
+    types = [contents_type]
+    projects=[]
+    free=None
+
 out_vars = ['out{}'.format(i) for i in range(len(types))]
 
 with open(out_file, 'w') as f:
@@ -21,14 +55,17 @@ with open(out_file, 'w') as f:
         print('#define UNUSED(x) (void)(x)', file=f)
     print('static void build_text(const struct lys_context *ctx, char* dest, size_t dest_len, const char* format, float render_milliseconds, char* **sum_names) {', file=f)
     if len(types) > 0:
-        for v, t in zip(out_vars, types):
-            print('  union {{ {} val; char* sum_name; }} {};'.format(t, v), file=f)
-        print('  FUT_CHECK(ctx->fut, futhark_entry_text_content(ctx->fut, {}, render_milliseconds, ctx->state));'.format(', '.join('&{}.val'.format(v) for v in out_vars)), file=f)
+        print('  {} contents;'.format(contents_ctype), file=f)
+        print('  FUT_CHECK(ctx->fut, futhark_entry_text_content(ctx->fut, &contents, render_milliseconds, ctx->state));', file=f)
+        for p, t, v in zip(projects, types, out_vars):
+            print(f'  union {{ {t} val; char* sum_name; }} {v};', file=f)
+            print(f'  FUT_CHECK(ctx->fut, {p}(ctx->fut, &{v}.val, contents));', file=f)
+        print(f'  FUT_CHECK(ctx->fut, {free}(ctx->fut, contents));', file=f)
         for v, i in zip(out_vars, range(len(out_vars))):
             print('  if (sum_names[{}] != NULL) {{'.format(i), file=f)
             print('    {v}.sum_name = sum_names[{i}][(int32_t) {v}.val];'.format(v=v, i=i), file=f)
             print('  }', file=f)
-        print('  snprintf(dest, dest_len, format, {});'.format(', '.join((s + ('.sum_name' if t == 'int32_t' else '.val')) for s, t in zip(out_vars, types))), file=f)
+        print('  snprintf(dest, dest_len, format, {});'.format(', '.join((s + ('.sum_name' if t == 'i32' else '.val')) for s, t in zip(out_vars, types))), file=f)
     else:
         for x in ['ctx', 'render_milliseconds', 'sum_names']:
             print('UNUSED({});'.format(x), file=f)

--- a/lib/github.com/diku-dk/lys/gen_printf.py
+++ b/lib/github.com/diku-dk/lys/gen_printf.py
@@ -9,7 +9,7 @@ self_dir, out_file, in_file = sys.argv[1:]
 with open(in_file) as f:
     manifest = json.load(f)
 
-contents_type = manifest['entry_points']['text_content']['outputs'][0]['type']
+contents_type = manifest['entry_points']['text_content']['output']['type']
 
 C_TYPE_MAPPING = { 'u8': 'uint8_t',
                    'u16': 'uint16_t',


### PR DESCRIPTION
This prepares Lys to accomodate the changes coming in https://github.com/diku-dk/futhark/pull/2410

It also makes gen_printf.py use the manifest instead of parsing the C header file.

I think I broke text content that is not a tuple, but why would you ever do that anyway?